### PR TITLE
Additional type removal

### DIFF
--- a/lib/lvelements/compiler/src/languagenodes.cpp
+++ b/lib/lvelements/compiler/src/languagenodes.cpp
@@ -1527,68 +1527,47 @@ void BaseNode::visitArrowFunction(BaseNode *parent, const TSNode &node){
     ArrowFunctionNode* enode = new ArrowFunctionNode(node);
     parent->addChild(enode);
 
-    bool arrowPassed = false;
-    uint32_t count = ts_node_child_count(node);
-    for ( uint32_t i = 0; i < count; ++i ){
-        TSNode child = ts_node_child(node, i);
+    // Function parameters
+    const TSNode parameters = BaseNode::nodeChildByFieldName(node, "parameters");
+    if (!ts_node_is_null(parameters)) {
+        enode->m_parameters = BaseNode::scanFormalParameters(parent, parameters);
+        enode->addChild(enode->m_parameters);
+    } else {
+        const TSNode parameter = BaseNode::nodeChildByFieldName(node, "parameter");
+        if (!ts_node_is_null(parameter)) {
+            enode->m_parameters = new ParameterListNode(parameter);
 
-        if ( strcmp(ts_node_type(child), "property_identifier") == 0 ){
-            enode->m_name = new IdentifierNode(child);
-        } else if ( strcmp(ts_node_type(child), "identifier") == 0 ){
-            auto nameNode = new IdentifierNode(child);
-            enode->m_parameters.push_back(nameNode);
-            enode->addChild(nameNode);
-        } else if ( strcmp(ts_node_type(child), "formal_parameters") == 0 ){
-            uint32_t paramterCount = ts_node_child_count(child);
-
-            for (uint32_t pc = 0; pc < paramterCount; ++pc){
-                TSNode ftpc = ts_node_child(child, pc);
-                if (strcmp(ts_node_type(ftpc), "identifier") == 0){
-                    auto nameNode = new IdentifierNode(ftpc);
-                    enode->m_parameters.push_back(nameNode);
-                    enode->addChild(nameNode);
-                } else if ( strcmp(ts_node_type(ftpc), "required_parameter") == 0 ){
-                    uint32_t paramterInteralCount = ts_node_child_count(ftpc);
-                    for (uint32_t pi = 0; pi < paramterInteralCount; ++pi){
-                        TSNode ftpci = ts_node_child(ftpc, pi);
-                        if (strcmp(ts_node_type(ftpci), "identifier") == 0){
-                            auto nameNode = new IdentifierNode(ftpci);
-                            enode->m_parameters.push_back(nameNode);
-                            enode->addChild(nameNode);
-                        }
-                    }
-                } else if ( strcmp(ts_node_type(ftpc), "optional_parameter") == 0 ){
-                    uint32_t paramterInteralCount = ts_node_child_count(ftpc);
-                    for (uint32_t pi = 0; pi < paramterInteralCount; ++pi){
-                        TSNode ftpci = ts_node_child(ftpc, pi);
-                        if (strcmp(ts_node_type(ftpci), "identifier") == 0){
-                            auto nameNode = new IdentifierNode(ftpci);
-                            enode->m_parameters.push_back(nameNode);
-                            enode->addChild(nameNode);
-                        }
-                    }
-                }
-            }
-        } else if ( strcmp(ts_node_type(child), "=>") == 0 ){
-            arrowPassed = true;
-        } else if ( strcmp(ts_node_type(child), "statement_block") == 0 ){
-            enode->m_body = new JsBlockNode(child);
-            enode->addChild(enode->m_body);
-            visitChildren(enode->m_body, child);
-        } else {
-            if ( arrowPassed ){
-                visit(enode, child);
-            }
+            auto nameNode = new IdentifierNode(parameter);
+            auto paramNode = new ParameterNode(parameter, nameNode);
+            enode->m_parameters->m_parameters.push_back(paramNode);
         }
     }
 
-    if (enode->m_body){
-        for (size_t i = 0; i != enode->m_parameters.size(); ++i){
-            addToDeclarations(enode->m_body, enode->m_parameters[i]);
-        }
-    } else {
-        for (size_t i = 0; i != enode->m_parameters.size(); ++i){
-            addToDeclarations(enode, enode->m_parameters[i]);
+    // Function return type
+    const TSNode returnType = BaseNode::nodeChildByFieldName(node, "return_type");
+    if (!ts_node_is_null(returnType)) {
+        enode->m_returnType = new TypeNode(returnType);
+        enode->addChild(enode->m_returnType);
+    }
+
+    // Function body
+    const TSNode body = BaseNode::nodeChildByFieldName(node, "body");
+    if (!ts_node_is_null(body)) {
+        enode->m_body = new JsBlockNode(body);
+        enode->addChild(enode->m_body);
+        visitChildren(enode->m_body, body);
+    }
+
+
+    if ( enode->m_parameters ){
+        if (enode->m_body ){
+            for (size_t i = 0; i != enode->m_parameters->m_parameters.size(); ++i){
+                addToDeclarations(enode->m_body, enode->m_parameters->m_parameters[i]->identifier());
+            }
+        } else {
+            for (size_t i = 0; i != enode->m_parameters->m_parameters.size(); ++i){
+                addToDeclarations(enode, enode->m_parameters->m_parameters[i]->identifier());
+            }
         }
     }
 }
@@ -2258,9 +2237,7 @@ std::string MethodDefinitionNode::toString(int indent) const{
 
 
 ArrowFunctionNode::ArrowFunctionNode(const TSNode &node)
-    : JsBlockNode(node, ArrowFunctionNode::nodeInfo() )
-    , m_name(nullptr)
-    , m_body(nullptr)
+    : FunctionNode(node, ArrowFunctionNode::nodeInfo() )
 {
 }
 
@@ -2268,17 +2245,15 @@ std::string ArrowFunctionNode::toString(int indent) const{
     std::string result;
     if ( indent > 0 )
         result.assign(indent * 2, ' ');
-    std::string name = "";
-    if ( m_name )
-        name = "(name " + m_name->rangeString() + ")";
 
-    result += "ArrowFunction " + rangeString() + name + "\n";
+    result += "ArrowFunction " + rangeString();
 
-    if ( m_parameters.size() > 0 ){
+    const std::size_t paramSize = m_parameters->parameters().size();
+    if ( paramSize > 0 ){
         std::string paramsResult;
         if ( indent > 0 )
             paramsResult.assign(indent * 2, ' ');
-        std::string parameters = "(no parameters: " + std::to_string(m_parameters.size()) + ")";
+        std::string parameters = "(no parameters: " + std::to_string(paramSize) + ")";
         result += paramsResult + "ParameterList " + rangeString() + parameters + "\n";
     }
 
@@ -2293,6 +2268,7 @@ FunctionNode::FunctionNode(const TSNode &node)
     : BaseNode(node, FunctionNode::nodeInfo())
     , m_parameters(nullptr)
     , m_body(nullptr)
+    , m_returnType(nullptr)
 {
 }
 

--- a/lib/lvelements/compiler/src/languagenodes.cpp
+++ b/lib/lvelements/compiler/src/languagenodes.cpp
@@ -1422,7 +1422,13 @@ void BaseNode::visitVariableDeclaration(BaseNode *parent, const TSNode &node){
 }
 
 void BaseNode::visitLexicalDeclaration(BaseNode *parent, const TSNode &node){
-    visitDeclarationForm(parent, node, VariableDeclarationNode::Let);
+    TSNode kind = BaseNode::nodeChildByFieldName(node, "kind");
+    VariableDeclarationNode::DeclarationForm mode = VariableDeclarationNode::Let;
+    if (!ts_node_is_null(kind) && strcmp(ts_node_type(kind), "const") == 0) {
+        mode = VariableDeclarationNode::Const;
+    }
+
+    visitDeclarationForm(parent, node, mode);
 }
 
 
@@ -1430,6 +1436,7 @@ void BaseNode::visitDeclarationForm(BaseNode * parent, const TSNode & node, int 
     VariableDeclarationNode* vdn = new VariableDeclarationNode(node);
     vdn->m_declarationForm = static_cast<VariableDeclarationNode::DeclarationForm>(form);
     parent->addChild(vdn);
+
     uint32_t count = ts_node_child_count(node);
     for ( uint32_t i = 0; i < count; ++i ){
         TSNode child = ts_node_child(node, i);

--- a/lib/lvelements/compiler/src/languagenodes_p.h
+++ b/lib/lvelements/compiler/src/languagenodes_p.h
@@ -970,6 +970,7 @@ public:
 
     ParameterListNode* parameters() const{ return m_parameters; }
     JsBlockNode* body() const{ return m_body; }
+    TypeNode* returnType() const{ return m_returnType; }
 
 protected:
     FunctionNode(const TSNode& node, const LanguageNodeInfo::ConstPtr& ni);
@@ -977,6 +978,7 @@ protected:
 private:
     ParameterListNode* m_parameters;
     JsBlockNode*       m_body;
+    TypeNode*          m_returnType;
 };
 
 class FunctionDeclarationNode: public FunctionNode{

--- a/lib/lvelements/compiler/src/languagenodes_p.h
+++ b/lib/lvelements/compiler/src/languagenodes_p.h
@@ -943,24 +943,6 @@ private:
     JsBlockNode*       m_body;
 };
 
-
-class ArrowFunctionNode: public JsBlockNode{
-    friend class BaseNode;
-    LANGUAGE_NODE_INFO(ArrowFunctionNode);
-public:
-    ArrowFunctionNode(const TSNode& node);
-
-    virtual std::string toString(int indent = 0) const;
-
-    IdentifierNode* name() const{ return m_name; }
-    std::vector<IdentifierNode*> parameters() const{ return m_parameters; }
-    JsBlockNode* body() const{ return m_body; }
-private:
-    IdentifierNode*    m_name;
-    std::vector<IdentifierNode*> m_parameters;
-    JsBlockNode*       m_body;
-};
-
 class FunctionNode: public BaseNode {
     friend class BaseNode;
     LANGUAGE_NODE_INFO(FunctionNode);
@@ -974,12 +956,20 @@ public:
 
 protected:
     FunctionNode(const TSNode& node, const LanguageNodeInfo::ConstPtr& ni);
-
-private:
     ParameterListNode* m_parameters;
     JsBlockNode*       m_body;
     TypeNode*          m_returnType;
 };
+
+class ArrowFunctionNode: public FunctionNode{
+    friend class BaseNode;
+    LANGUAGE_NODE_INFO(ArrowFunctionNode);
+public:
+    ArrowFunctionNode(const TSNode& node);
+
+    virtual std::string toString(int indent = 0) const;
+};
+
 
 class FunctionDeclarationNode: public FunctionNode{
     friend class BaseNode;

--- a/lib/lvelements/compiler/src/languagenodestojs.cpp
+++ b/lib/lvelements/compiler/src/languagenodestojs.cpp
@@ -1156,7 +1156,12 @@ void LanguageNodesToJs::convertFunctionDeclaration(
         }
     }
 
-    *compose << "\n" << indent(indentValue + 2) << "function " << (funcNode->name() ? slice(source, funcNode->name()) : "") << "(" << paramList << ")";
+    std::string returnType = "";
+    if (ctx->outputTypes && funcNode->returnType() != nullptr) {
+        returnType = slice(source, funcNode->returnType());
+    }
+
+    *compose << "\n" << indent(indentValue + 2) << "function " << (funcNode->name() ? slice(source, funcNode->name()) : "") << "(" << paramList << ")" << returnType;
 
     if ( funcNode->body() ){
         JSSection* jssection = new JSSection;

--- a/lib/lvelements/compiler/src/languagenodestojs_p.h
+++ b/lib/lvelements/compiler/src/languagenodestojs_p.h
@@ -88,6 +88,14 @@ public:
         BaseNode::ConversionContext *ctx
     );
 
+    void convertFunction(
+        FunctionNode* node,
+        const std::string &source,
+        std::vector<ElementsInsertion *> &sections,
+        int indentValue,
+        BaseNode::ConversionContext *ctx
+    );
+
     void convertPropertyDeclaration(
         PropertyDeclarationNode* node,
         const std::string& source,

--- a/lib/lvelements/compiler/src/languagenodestojs_p.h
+++ b/lib/lvelements/compiler/src/languagenodestojs_p.h
@@ -80,6 +80,14 @@ public:
         BaseNode::ConversionContext *ctx
     );
 
+    void convertArrowFunction(
+        ArrowFunctionNode* node,
+        const std::string &source,
+        std::vector<ElementsInsertion *> &sections,
+        int indentValue,
+        BaseNode::ConversionContext *ctx
+    );
+
     void convertPropertyDeclaration(
         PropertyDeclarationNode* node,
         const std::string& source,

--- a/lib/lvelements/compiler/test/unit/data/ParserTest16.lv.js
+++ b/lib/lvelements/compiler/test/unit/data/ParserTest16.lv.js
@@ -23,7 +23,7 @@ export class TodoList extends Ul{
     }
 
     run(){
-        this.children = this.items.map( s => new TodoListItem(s))
+        this.children = this.items.map( (s) => new TodoListItem(s))
         this.children = this.items.map( (s, e) => new TodoListItem(s, e))
     }
 }

--- a/lib/lvelements/compiler/test/unit/data/ParserTypeTest01.lv
+++ b/lib/lvelements/compiler/test/unit/data/ParserTypeTest01.lv
@@ -5,7 +5,15 @@ component X{
        let y:string = 20
        let {m, n} = {m: 1, n: 2}
        const z:number = 100
+       
        function test(c:number, d:number): string {
+       
        }
+
+       const test2 = (a:number, b:number): number => {
+
+       }
+
+       const test3 = s => new Array(100)
    }
 }

--- a/lib/lvelements/compiler/test/unit/data/ParserTypeTest01.lv
+++ b/lib/lvelements/compiler/test/unit/data/ParserTypeTest01.lv
@@ -15,5 +15,7 @@ component X{
        }
 
        const test3 = s => new Array(100)
+
+       const simple = function(a:number):number {}
    }
 }

--- a/lib/lvelements/compiler/test/unit/data/ParserTypeTest01.lv
+++ b/lib/lvelements/compiler/test/unit/data/ParserTypeTest01.lv
@@ -5,7 +5,7 @@ component X{
        let y:string = 20
        let {m, n} = {m: 1, n: 2}
        const z:number = 100
-       function test(c:number, d:number){
+       function test(c:number, d:number): string {
        }
    }
 }

--- a/lib/lvelements/compiler/test/unit/data/ParserTypeTest01.lv
+++ b/lib/lvelements/compiler/test/unit/data/ParserTypeTest01.lv
@@ -4,6 +4,7 @@ component X{
        let x:number = 100
        let y:string = 20
        let {m, n} = {m: 1, n: 2}
+       const z:number = 100
        function test(c:number, d:number){
        }
    }

--- a/lib/lvelements/compiler/test/unit/data/ParserTypeTest01.lv.js
+++ b/lib/lvelements/compiler/test/unit/data/ParserTypeTest01.lv.js
@@ -1,3 +1,4 @@
+import {Array} from '__UNRESOLVED__'
 export class X extends Element{
 
     constructor(){
@@ -14,5 +15,10 @@ export class X extends Element{
         let {m, n} = {m: 1, n: 2}
         const z = 100
         function test(c,d){}
+        const test2 = (a, b) => {
+
+        }
+
+        const test3 = (s) => new Array(100)
    }
 }

--- a/lib/lvelements/compiler/test/unit/data/ParserTypeTest01.lv.js
+++ b/lib/lvelements/compiler/test/unit/data/ParserTypeTest01.lv.js
@@ -20,5 +20,8 @@ export class X extends Element{
         }
 
         const test3 = (s) => new Array(100)
+
+
+       const simple = function(a){}
    }
 }

--- a/lib/lvelements/compiler/test/unit/data/ParserTypeTest01.lv.js
+++ b/lib/lvelements/compiler/test/unit/data/ParserTypeTest01.lv.js
@@ -12,6 +12,7 @@ export class X extends Element{
         let x = 100
         let y = 20
         let {m, n} = {m: 1, n: 2}
+        const z = 100
         function test(c,d){}
    }
 }

--- a/lib/lvelements/compiler/test/unit/data/ParserTypeTest01.lv.ts
+++ b/lib/lvelements/compiler/test/unit/data/ParserTypeTest01.lv.ts
@@ -1,3 +1,4 @@
+import {Array} from '__UNRESOLVED__'
 export class X extends Element{
 
     constructor(){
@@ -14,5 +15,8 @@ export class X extends Element{
         let {m, n} = {m: 1, n: 2}
         const z:number = 100
         function test(c:number,d:number): string{}
+        const test2 = (a:number, b:number): number => {}
+
+        const test3 = (s) => new Array(100)
    }
 }

--- a/lib/lvelements/compiler/test/unit/data/ParserTypeTest01.lv.ts
+++ b/lib/lvelements/compiler/test/unit/data/ParserTypeTest01.lv.ts
@@ -13,6 +13,6 @@ export class X extends Element{
         let y:string = 20
         let {m, n} = {m: 1, n: 2}
         const z:number = 100
-        function test(c:number,d:number){}
+        function test(c:number,d:number): string{}
    }
 }

--- a/lib/lvelements/compiler/test/unit/data/ParserTypeTest01.lv.ts
+++ b/lib/lvelements/compiler/test/unit/data/ParserTypeTest01.lv.ts
@@ -12,6 +12,7 @@ export class X extends Element{
         let x:number = 100
         let y:string = 20
         let {m, n} = {m: 1, n: 2}
+        const z:number = 100
         function test(c:number,d:number){}
    }
 }

--- a/lib/lvelements/compiler/test/unit/data/ParserTypeTest01.lv.ts
+++ b/lib/lvelements/compiler/test/unit/data/ParserTypeTest01.lv.ts
@@ -18,5 +18,7 @@ export class X extends Element{
         const test2 = (a:number, b:number): number => {}
 
         const test3 = (s) => new Array(100)
+
+       const simple = function(a: number):number{}
    }
 }

--- a/lib/lvelements/compiler/test/unit/parsetest.cpp
+++ b/lib/lvelements/compiler/test/unit/parsetest.cpp
@@ -60,7 +60,7 @@ void testFileParse(const std::string& name){
             parser->destroy(expectedAST);
 
             if ( !compare.isEqual() ){
-                vlog().e() << "File: " << name;
+                vlog().e() << "File: " << name << ".lv" << expectation;
                 vlog().e() << compare.errorString();
                 vlog().e() << conversion;
             }


### PR DESCRIPTION
This PR handles the type removal(in JS) for the following declarations:
- const
- functions / simple functions / arrow functions

It also cleans up some of the logic for fetching parameters / names for declarations.

Items left to do as part of this effort:
- class methods
- class static methods
- try catch blocks ( catch( e:Exception) )
- +other: https://github.com/tree-sitter/tree-sitter-typescript/blob/master/common/define-grammar.js